### PR TITLE
base bass basic

### DIFF
--- a/api.js
+++ b/api.js
@@ -9,10 +9,14 @@
   var repeating = /^(.)\1+$/
   var glyph = /[\u0300-\u036f]/g
   var norm = "".normalize
+  var base = norm ? bass : basic
 
-  function grapheme(txt) {
-    return digit.test(txt) ? "" + txt :
-      norm.call(txt, "NFD").replace(glyph, "")
+  function bass(txt) {
+    return norm.call(txt, "NFD").replace(glyph, "")
+  }
+
+  function basic(txt) {
+    return "" + txt
   }
 
   function modulo(n) {
@@ -21,7 +25,7 @@
   }
 
   function place(letter) {
-    letter = grapheme(lower.call(letter))
+    letter = base(lower.call(letter))
     return bet.indexOf(letter) + 1
   }
 
@@ -61,7 +65,9 @@
     return api[method](txt)
   }
 
-  api.grapheme = grapheme
+  api.base = base
+  api.bass = bass
+  api.basic = basic
   api.life = vida
   api.modulo = modulo
   api.raiz = raiz

--- a/test.js
+++ b/test.js
@@ -42,8 +42,8 @@ assert.ok(api.raiz("FF") === 3)
 assert.ok(api.raiz("firefox") === 2)
 console.log("ok raiz")
 
-assert.ok(api.grapheme("Áá"), "Aa")
-console.log("ok grapheme")
+assert.ok(api.base("Áá"), "Aa")
+console.log("ok base")
 
 assert.ok(api.raiz === api.root)
 assert.ok(api.vida === api.life)


### PR DESCRIPTION
choose `base` as name for glyph remover

- [base because](https://linguistics.stackexchange.com/q/40549/34100)
- [NFD technique](https://stackoverflow.com/a/37511463/770127)
- uses underlying `bass` if normalizable
- uses underlying `basic` as fallback
- `base` is the public method
- `base` translates to `base`