### PR TITLE
autocomplete off

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
   </header>
   <form id="formulario" method="get">
     <label for="entrada">calcular</label>
-    <input id="entrada" name="_" placeholder="&hellip;" size="26">
+    <input id="entrada" name="_" placeholder="&hellip;" size="26" autocomplete="off">
     <button id="=" type="submit">=</button>
     <div id="status" role="status">
       <output for="suma" name="suma">?</output>


### PR DESCRIPTION
remove [autocomplete](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#values) to ensure [privacy](https://ryanve.dev/numerologia/?_=privacy) on shared computers and because the autocompletion overlays where the output data is and it seems better to to keep it freeform while seeing the changes with each character you type